### PR TITLE
Fix: Changes FTS to Fortress

### DIFF
--- a/dev/feeds.yaml
+++ b/dev/feeds.yaml
@@ -537,8 +537,13 @@ FTS-USD:
     - fetcher:
         name: CoingeckoPrice
         params:
-          id: footballstars
+          id: fortress
           currency: USD
+    - fetcher:
+        name: CoinmarketcapPrice
+        params:
+          symbol: FTS
+          convert: USD
 
 # histo
 

--- a/feeds.yaml
+++ b/feeds.yaml
@@ -6799,8 +6799,13 @@ FTS-USD:
     - fetcher:
         name: CoingeckoPrice
         params:
-          id: footballstars
+          id: fortress
           currency: USD
+    - fetcher:
+        name: CoinmarketcapPrice
+        params:
+          symbol: FTS
+          convert: USD
 
 # histo
 


### PR DESCRIPTION
The last PR put FTS as Football Stars. It is Fortress, instead. Also adds one more source of data for better trustability.

Related to [OR-682](https://umbnetwork.atlassian.net/browse/OR-682?atlOrigin=eyJpIjoiZDJhNmVkYTZiMjM2NGQwNDlkZDM5MDUzOGRiMTBhYjAiLCJwIjoiaiJ9)