### PR TITLE
fix: Remove DAFI prices [prod]

### DIFF
--- a/feeds.yaml
+++ b/feeds.yaml
@@ -5115,6 +5115,21 @@ FTS-USD:
           symbol: FTS
           convert: USD
 
+# On-Chain
+
+FIXED_UMB:V-COUNT:
+  discrepancy: 0.0
+  precision: 0
+  inputs:
+    - fetcher:
+        name: OnChainData
+        params:
+          address: "0x58b1af723C529e00293229cbAfcAE2217BF3dBd1"
+          method: getNumberOfValidators
+          inputs: []
+          outputs: [ uint256 ]
+          args: []
+
 # histo
 
 ETH-USD-TWAP-1day:

--- a/feeds.yaml
+++ b/feeds.yaml
@@ -5100,16 +5100,6 @@ ZDEX-EUR:
           fsym: ZDEX
           tsyms: EUR
 
-DAFI-USD:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: DAFI
-          tsyms: USD
-
 FTS-USD:
   discrepancy: 1.0
   precision: 8
@@ -5126,32 +5116,6 @@ FTS-USD:
           convert: USD
 
 # histo
-
-DAFI-USD-TWAP-1day:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoHour
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 25
-      calculator:
-        name: TWAP
-
-DAFI-USD-VWAP-1week:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoDay
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 8
-      calculator:
-        name: VWAP
 
 ETH-USD-TWAP-1day:
   discrepancy: 1.0

--- a/feedsOnChain.yaml
+++ b/feedsOnChain.yaml
@@ -135,16 +135,6 @@ REN-USD:
           fsym: REN
           tsym: USD
 
-DAFI-USD:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: DAFI
-          tsyms: USD
-
 AAVE-USD:
   discrepancy: 1.0
   precision: 2
@@ -211,31 +201,3 @@ GVol-ETH-IV-28days:
         params:
           query: twentyEightDayIv
           sym: ETH
-          
-# histo
-
-DAFI-USD-TWAP-1day:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoHour
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 25
-      calculator:
-        name: TWAP
-
-DAFI-USD-VWAP-1week:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoDay
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 8
-      calculator:
-        name: VWAP

--- a/prod/bsc/feeds.yaml
+++ b/prod/bsc/feeds.yaml
@@ -5100,16 +5100,6 @@ ZDEX-EUR:
           fsym: ZDEX
           tsyms: EUR
 
-DAFI-USD:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: DAFI
-          tsyms: USD
-
 FTS-USD:
   discrepancy: 1.0
   precision: 8
@@ -5126,32 +5116,6 @@ FTS-USD:
           convert: USD
 
 # histo
-
-DAFI-USD-TWAP-1day:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoHour
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 25
-      calculator:
-        name: TWAP
-
-DAFI-USD-VWAP-1week:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoDay
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 8
-      calculator:
-        name: VWAP
 
 ETH-USD-TWAP-1day:
   discrepancy: 1.0

--- a/prod/bsc/feeds.yaml
+++ b/prod/bsc/feeds.yaml
@@ -5115,6 +5115,21 @@ FTS-USD:
           symbol: FTS
           convert: USD
 
+# On-Chain
+
+FIXED_UMB:V-COUNT:
+  discrepancy: 0.0
+  precision: 0
+  inputs:
+    - fetcher:
+        name: OnChainData
+        params:
+          address: "0xb2C6c4162c0d2B6963C62A9133331b4D0359AA34"
+          method: getNumberOfValidators
+          inputs: []
+          outputs: [ uint256 ]
+          args: []
+
 # histo
 
 ETH-USD-TWAP-1day:

--- a/prod/bsc/feedsOnChain.yaml
+++ b/prod/bsc/feedsOnChain.yaml
@@ -135,16 +135,6 @@ REN-USD:
           fsym: REN
           tsym: USD
 
-DAFI-USD:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: DAFI
-          tsyms: USD
-
 AAVE-USD:
   discrepancy: 1.0
   precision: 2
@@ -211,31 +201,3 @@ GVol-ETH-IV-28days:
         params:
           query: twentyEightDayIv
           sym: ETH
-          
-# histo
-
-DAFI-USD-TWAP-1day:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoHour
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 25
-      calculator:
-        name: TWAP
-
-DAFI-USD-VWAP-1week:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoDay
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 8
-      calculator:
-        name: VWAP

--- a/prod/eth/feeds.yaml
+++ b/prod/eth/feeds.yaml
@@ -5115,6 +5115,21 @@ FTS-USD:
           symbol: FTS
           convert: USD
 
+# On-Chain
+
+FIXED_UMB:V-COUNT:
+  discrepancy: 0.0
+  precision: 0
+  inputs:
+    - fetcher:
+        name: OnChainData
+        params:
+          address: "0x58b1af723C529e00293229cbAfcAE2217BF3dBd1"
+          method: getNumberOfValidators
+          inputs: []
+          outputs: [ uint256 ]
+          args: []
+
 # histo
 
 ETH-USD-TWAP-1day:

--- a/prod/eth/feeds.yaml
+++ b/prod/eth/feeds.yaml
@@ -5100,16 +5100,6 @@ ZDEX-EUR:
           fsym: ZDEX
           tsyms: EUR
 
-DAFI-USD:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: DAFI
-          tsyms: USD
-
 FTS-USD:
   discrepancy: 1.0
   precision: 8
@@ -5126,32 +5116,6 @@ FTS-USD:
           convert: USD
 
 # histo
-
-DAFI-USD-TWAP-1day:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoHour
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 25
-      calculator:
-        name: TWAP
-
-DAFI-USD-VWAP-1week:
-  discrepancy: 1.0
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoDay
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 8
-      calculator:
-        name: VWAP
 
 ETH-USD-TWAP-1day:
   discrepancy: 1.0

--- a/prod/eth/feedsOnChain.yaml
+++ b/prod/eth/feedsOnChain.yaml
@@ -135,16 +135,6 @@ REN-USD:
           fsym: REN
           tsym: USD
 
-DAFI-USD:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: DAFI
-          tsyms: USD
-
 AAVE-USD:
   discrepancy: 1.0
   precision: 2
@@ -211,31 +201,3 @@ GVol-ETH-IV-28days:
         params:
           query: twentyEightDayIv
           sym: ETH
-          
-# histo
-
-DAFI-USD-TWAP-1day:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoHour
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 25
-      calculator:
-        name: TWAP
-
-DAFI-USD-VWAP-1week:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CoinmarketcapHistoDay
-        params:
-          symbol: DAFI
-          convert: USD
-          count: 8
-      calculator:
-        name: VWAP


### PR DESCRIPTION
This removes DAFI from both FCD and L2D. Also adds UMB:V-COUNT (Umbrella Validators Count) as L2D.