### PR TITLE
chore: Remove Coinmarketcap

### DIFF
--- a/prod/bsc/feeds.yaml
+++ b/prod/bsc/feeds.yaml
@@ -5040,11 +5040,6 @@ UMB-USD:
           id: umbrella-network
           currency: USD
     - fetcher:
-        name: CoinmarketcapPrice
-        params:
-          symbol: UMB
-          convert: USD
-    - fetcher:
         name: CryptoComparePrice
         params:
           fsym: UMB
@@ -5109,11 +5104,6 @@ FTS-USD:
         params:
           id: fortress
           currency: USD
-    - fetcher:
-        name: CoinmarketcapPrice
-        params:
-          symbol: FTS
-          convert: USD
 
 INT-USD:
   discrepancy: 1.0

--- a/prod/bsc/feedsOnChain.yaml
+++ b/prod/bsc/feedsOnChain.yaml
@@ -155,11 +155,6 @@ UMB-USD:
           id: umbrella-network
           currency: usd
     - fetcher:
-        name: CoinmarketcapPrice
-        params:
-          symbol: UMB
-          convert: USD
-    - fetcher:
         name: CryptoComparePrice
         params:
           fsym: UMB
@@ -174,11 +169,6 @@ FTS-USD:
         params:
           id: fortress
           currency: USD
-    - fetcher:
-        name: CoinmarketcapPrice
-        params:
-          symbol: FTS
-          convert: USD
 
 # GVol
 


### PR DESCRIPTION
Coinmarketcap is no longer used by validators. Removed it.