### PR TITLE
feature: knit-usd and fuse-usd

### DIFF
--- a/dev/bsc/feeds.yaml
+++ b/dev/bsc/feeds.yaml
@@ -941,6 +941,26 @@ DEP-USD:
           id: deapcoin
           currency: USD
 
+FUSE-USD:
+  discrepancy: 1.0
+  precision: 6
+  inputs:
+    - fetcher:
+        name: CoingeckoPrice
+        params:
+          id: fuse-network-token
+          currency: USD
+
+KFT-USD:
+  discrepancy: 1.0
+  precision: 6
+  inputs:
+    - fetcher:
+        name: CoingeckoPrice
+        params:
+          id: knit-finance
+          currency: USD
+
 # On-Chain
 
 FIXED_UMB:V-COUNT:


### PR DESCRIPTION
This adds KFT-USD (Knit) and FUSE-USD (Fuse) as L2D. Both are provided by Coingecko.

Refers to: [OR-1241](https://umbnetwork.atlassian.net/browse/OR-1241) and [OR-1242](https://umbnetwork.atlassian.net/browse/OR-1242)