### PR TITLE
feature: MAHA-USD as FCD [dev]

### DIFF
--- a/dev/bsc/feedsOnChain.yaml
+++ b/dev/bsc/feedsOnChain.yaml
@@ -140,17 +140,27 @@ CNTR-USD:
           id: centaur
           currency: USD
 
-# GVol
-
-GVol-BTC-IV-28days:
+MAHA-USD:
   discrepancy: 1.0
   precision: 2
   inputs:
     - fetcher:
-        name: GVolImpliedVolatility
+        name: CoingeckoPrice
         params:
-          query: twentyEightDayIv
-          sym: BTC
+          id: mahadao
+          currency: USD
+
+# GVol
+
+# GVol-BTC-IV-28days:
+#   discrepancy: 1.0
+#   precision: 2
+#   inputs:
+#     - fetcher:
+#         name: GVolImpliedVolatility
+#         params:
+#           query: twentyEightDayIv
+#           sym: BTC
 
 GVol-ETH-IV-28days:
   discrepancy: 1.0


### PR DESCRIPTION
Replaces GVol-BTC-IV-28days with MAHA-USD at FCDs.