### PR TITLE
feature: MAHA-USD as FCD [prod]

### DIFF
--- a/prod/bsc/feedsOnChain.yaml
+++ b/prod/bsc/feedsOnChain.yaml
@@ -170,17 +170,27 @@ FTS-USD:
           id: fortress
           currency: USD
 
-# GVol
-
-GVol-BTC-IV-28days:
+MAHA-USD:
   discrepancy: 1.0
   precision: 2
   inputs:
     - fetcher:
-        name: GVolImpliedVolatility
+        name: CoingeckoPrice
         params:
-          query: twentyEightDayIv
-          sym: BTC
+          id: mahadao
+          currency: USD
+
+# GVol
+
+# GVol-BTC-IV-28days:
+#   discrepancy: 1.0
+#   precision: 2
+#   inputs:
+#     - fetcher:
+#         name: GVolImpliedVolatility
+#         params:
+#           query: twentyEightDayIv
+#           sym: BTC
 
 GVol-ETH-IV-28days:
   discrepancy: 1.0


### PR DESCRIPTION
Replaces GVol-BTC-IV-28days with MAHA-USD at FCDs.

[OR-1296](https://umbnetwork.atlassian.net/browse/OR-1296)