### PR TITLE
chore: Remove MAHA-USD from L2D and GVol-ETH [dev]

### DIFF
--- a/dev/bsc/feeds.yaml
+++ b/dev/bsc/feeds.yaml
@@ -897,15 +897,6 @@ KFT-USD:
         params:
           id: knit-finance
           currency: USD
-MAHA-USD:
-  discrepancy: 1
-  precision: 3
-  inputs:
-    - fetcher:
-        name: CoingeckoPrice
-        params:
-          id: mahadao
-          currency: USD
 FIXED_UMB:V-COUNT:
   discrepancy: 0
   precision: 0

--- a/dev/bsc/feedsOnChain.yaml
+++ b/dev/bsc/feedsOnChain.yaml
@@ -162,12 +162,12 @@ MAHA-USD:
 #           query: twentyEightDayIv
 #           sym: BTC
 
-GVol-ETH-IV-28days:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: GVolImpliedVolatility
-        params:
-          query: twentyEightDayIv
-          sym: ETH
+# GVol-ETH-IV-28days:
+#   discrepancy: 1.0
+#   precision: 2
+#   inputs:
+#     - fetcher:
+#         name: GVolImpliedVolatility
+#         params:
+#           query: twentyEightDayIv
+#           sym: ETH


### PR DESCRIPTION
MAHA-USD will only be FCD. GVol-ETH is commented to be reimplemented in the future.

[OR-1301](https://umbnetwork.atlassian.net/browse/OR-1301)