### PR TITLE
remove some CryptoComparePrice feeds

### DIFF
--- a/prod/bsc/feeds-russel2000.yaml
+++ b/prod/bsc/feeds-russel2000.yaml
@@ -4905,26 +4905,6 @@ UNO-USD:
           id: uno-re
           currency: USD
 
-ZDEX-USD:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: ZDEX
-          tsyms: USD
-
-ZDEX-EUR:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: ZDEX
-          tsyms: EUR
-
 INT-USD:
   discrepancy: 1.0
   precision: 6
@@ -4934,16 +4914,6 @@ INT-USD:
         params:
           id: internet-node-token
           currency: USD
-
-MATTER-USDT:
-  discrepancy: 1
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: MATTER
-          tsyms: USDT
 
 UFT-USD:
   discrepancy: 1.0

--- a/prod/bsc/feeds.yaml
+++ b/prod/bsc/feeds.yaml
@@ -4900,26 +4900,6 @@ UNO-USD:
           id: uno-re
           currency: USD
 
-ZDEX-USD:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: ZDEX
-          tsyms: USD
-
-ZDEX-EUR:
-  discrepancy: 1.0
-  precision: 2
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: ZDEX
-          tsyms: EUR
-
 INT-USD:
   discrepancy: 1.0
   precision: 6
@@ -4929,16 +4909,6 @@ INT-USD:
         params:
           id: internet-node-token
           currency: USD
-
-MATTER-USDT:
-  discrepancy: 1
-  precision: 4
-  inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: MATTER
-          tsyms: USDT
 
 UFT-USD:
   discrepancy: 1.0
@@ -5054,11 +5024,6 @@ AKITA-ETH:
   discrepancy: 1.0
   precision: 12
   inputs:
-    - fetcher:
-        name: CryptoComparePrice
-        params:
-          fsym: AKITA
-          tsyms: ETH
     - fetcher:
         name: CoingeckoPrice
         params:


### PR DESCRIPTION
Remove CytpoCompare API fetcher as a data source for below layer 2 feeds:

- AKITA-ETH



Remove the following feeds from layer 2 data:

- ZDEX-USD
- ZDEX-EUR
- MATTER-USDT