### PR TITLE
Update deviation threshold for stables

### DIFF
--- a/prod/onChainData128.8.yaml
+++ b/prod/onChainData128.8.yaml
@@ -21,7 +21,7 @@ USDC-USD:
   discrepancy: 0.5
   precision: 8
   heartbeat: 21600
-  trigger: 1.0
+  trigger: 0.1
   interval: 60
   chains: [ linea ]
   inputs:
@@ -40,7 +40,7 @@ USDT-USD:
   discrepancy: 0.5
   precision: 8
   heartbeat: 21600
-  trigger: 1.0
+  trigger: 0.1
   interval: 60
   chains: [ linea ]
   inputs:


### PR DESCRIPTION
Set deviation threshold as 0.1% for stables pricefeeds.